### PR TITLE
Separate at_parser initialization from allocation.

### DIFF
--- a/include/attentive/parser.h
+++ b/include/attentive/parser.h
@@ -66,6 +66,20 @@ struct at_parser_callbacks {
 struct at_parser *at_parser_alloc(const struct at_parser_callbacks *cbs, size_t bufsize, void *priv);
 
 /**
+ * Initialize a parser instance.
+ *
+ * Initialize an already allocated at_parser instance.
+ *
+ * @param parser Parser instance.
+ * @param cbs Parser callbacks. Structure is not copied; must persist for
+ *            the lifetime of the parser.
+ * @param buf Response buffer. Must be at least bufsize bytes long.
+ * @param bufsize Response buffer size on bytes.
+ * @param priv Private argument; passed to callbacks.
+ */
+void at_parser_init(struct at_parser *parser, const struct at_parser_callbacks *cbs, void *buf, size_t bufsize, void *priv);
+
+/**
  * Reset parser instance to initial state.
  *
  * @param parser Parser instance.

--- a/src/parser.c
+++ b/src/parser.c
@@ -63,20 +63,27 @@ struct at_parser *at_parser_alloc(const struct at_parser_callbacks *cbs, size_t 
     }
 
     /* Allocate response buffer. */
-    parser->buf = malloc(bufsize);
-    if (parser->buf == NULL) {
+    void *buf = malloc(bufsize);
+    if (buf == NULL) {
         free(parser);
         errno = ENOMEM;
         return NULL;
     }
+
+    at_parser_init(parser, cbs, buf, bufsize, priv);
+
+    return parser;
+}
+
+void at_parser_init(struct at_parser *parser, const struct at_parser_callbacks *cbs, void *buf, size_t bufsize, void *priv)
+{
     parser->cbs = cbs;
+    parser->buf = buf;
     parser->buf_size = bufsize;
     parser->priv = priv;
 
     /* Prepare instance. */
     at_parser_reset(parser);
-
-    return parser;
 }
 
 void at_parser_reset(struct at_parser *parser)


### PR DESCRIPTION
This allows the calling code to allocate their parser and buffer separately, possibly on the stack or static storage.