### PR TITLE
Hide data logging behind an ATTENTIVE_DEBUG define.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,17 @@
 * Telit modems (SELINT 2 compatibility level)
 * Simcom SIM800 series
 
+## Debugging
+
+The library is trying to be silent by default. To enable additional debug logs
+during development `ATTENTIVE_DEBUG` can be defined.
+
 ## License
 
 Attentive was written and open sourced by Kosma Moczek while working at [Cloud Your Car](https://cloudyourcar.com/).
 
 > Copyright © 2014-now Kosma Moczek \<kosma@kosma.pl\>
-> 
+>
 > This program is free software. It comes without any warranty, to the extent
 > permitted by applicable law. You can redistribute it and/or modify it under
 > the terms of the Do What The Fuck You Want To Public License, Version 2, as

--- a/src/at-unix.c
+++ b/src/at-unix.c
@@ -312,7 +312,9 @@ const char *at_command(struct at *at, const char *format, ...)
         return NULL;
     }
 
+#if definedf ATTENTIVE_DEBUG
     printf("> %s\n", line);
+#endif
 
     /* Append modem-style newline. */
     line[len++] = '\r';
@@ -325,7 +327,9 @@ const char *at_command_raw(struct at *at, const void *data, size_t size)
 {
     struct at_unix *priv = (struct at_unix *) at;
 
+#if defined(ATTENTIVE_DEBUG)
     printf("> [%zu bytes]\n", size);
+#endif
 
     return _at_command(priv, data, size);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -172,8 +172,10 @@ static void parser_handle_line(struct at_parser *parser)
     const char *line = parser->buf + parser->buf_current;
     size_t len = parser->buf_used - parser->buf_current;
 
+#if defined(ATTENTIVE_DEBUG)
     /* Log the received line. */
     printf("< '%.*s'\n", (int) len, line);
+#endif
 
     /* Determine response type. */
     enum at_response_type type = AT_RESPONSE_UNKNOWN;


### PR DESCRIPTION
This particularly matters for `parser.c` where `printf` might not be available.