### PR TITLE
Add missing C++ guards to headers

### DIFF
--- a/include/attentive/at-unix.h
+++ b/include/attentive/at-unix.h
@@ -9,7 +9,7 @@
 #ifndef ATTENTIVE_AT_UNIX_H
 #define ATTENTIVE_AT_UNIX_H
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -26,7 +26,7 @@ extern "C" {
  */
 struct at *at_alloc_unix(const char *devpath, speed_t baudrate);
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/attentive/at-unix.h
+++ b/include/attentive/at-unix.h
@@ -9,6 +9,10 @@
 #ifndef ATTENTIVE_AT_UNIX_H
 #define ATTENTIVE_AT_UNIX_H
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #include <termios.h>
 
 #include <attentive/at.h>
@@ -21,6 +25,10 @@
  * @returns Instance pointer on success, NULL and sets errno on failure.
  */
 struct at *at_alloc_unix(const char *devpath, speed_t baudrate);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 

--- a/include/attentive/at.h
+++ b/include/attentive/at.h
@@ -9,6 +9,10 @@
 #ifndef ATTENTIVE_AT_H
 #define ATTENTIVE_AT_H
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #include <attentive/parser.h>
 
 /*
@@ -162,6 +166,10 @@ const char *at_command_raw(struct at *at, const void *data, size_t size);
             return -1;                                                      \
         }                                                                   \
     } while (0)
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 

--- a/include/attentive/at.h
+++ b/include/attentive/at.h
@@ -9,7 +9,7 @@
 #ifndef ATTENTIVE_AT_H
 #define ATTENTIVE_AT_H
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -167,7 +167,7 @@ const char *at_command_raw(struct at *at, const void *data, size_t size);
         }                                                                   \
     } while (0)
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/attentive/cellular.h
+++ b/include/attentive/cellular.h
@@ -9,7 +9,12 @@
 #ifndef ATTENTIVE_CELLULAR_H
 #define ATTENTIVE_CELLULAR_H
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
@@ -127,6 +132,10 @@ void cellular_telit2_free(struct cellular *modem);
 
 struct cellular *cellular_sim800_alloc(void);
 void cellular_sim800_free(struct cellular *modem);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 

--- a/include/attentive/cellular.h
+++ b/include/attentive/cellular.h
@@ -9,7 +9,7 @@
 #ifndef ATTENTIVE_CELLULAR_H
 #define ATTENTIVE_CELLULAR_H
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -133,7 +133,7 @@ void cellular_telit2_free(struct cellular *modem);
 struct cellular *cellular_sim800_alloc(void);
 void cellular_sim800_free(struct cellular *modem);
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/attentive/parser.h
+++ b/include/attentive/parser.h
@@ -9,6 +9,10 @@
 #ifndef ATTENTIVE_PARSER_H
 #define ATTENTIVE_PARSER_H
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -129,6 +133,10 @@ void at_parser_free(struct at_parser *parser);
  * @returns True if found, false otherwise.
  */
 bool at_prefix_in_table(const char *line, const char *const table[]);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif
 

--- a/include/attentive/parser.h
+++ b/include/attentive/parser.h
@@ -9,7 +9,7 @@
 #ifndef ATTENTIVE_PARSER_H
 #define ATTENTIVE_PARSER_H
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -134,7 +134,7 @@ void at_parser_free(struct at_parser *parser);
  */
 bool at_prefix_in_table(const char *line, const char *const table[]);
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/modem/common.h
+++ b/src/modem/common.h
@@ -9,6 +9,10 @@
 #ifndef MODEM_COMMON_H
 #define MODEM_COMMON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <attentive/cellular.h>
 
 /**
@@ -57,6 +61,10 @@ int cellular_op_creg(struct cellular *modem);
 int cellular_op_rssi(struct cellular *modem);
 int cellular_op_clock_gettime(struct cellular *modem, struct timespec *ts);
 int cellular_op_clock_settime(struct cellular *modem, const struct timespec *ts);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
This avoids linker errors when included from C++ sources.
