### PR TITLE
Fix typo in ATTENTIVE_DEBUG check.

### DIFF
--- a/src/at-unix.c
+++ b/src/at-unix.c
@@ -312,7 +312,7 @@ const char *at_command(struct at *at, const char *format, ...)
         return NULL;
     }
 
-#if definedf ATTENTIVE_DEBUG
+#if defined(ATTENTIVE_DEBUG)
     printf("> %s\n", line);
 #endif
 


### PR DESCRIPTION
Things went a little fast in the previous PR. Forgive me while I'm trying to sort out the older commits. There are some things needed in order to get the examples and tests to compile cleanly with a modern compiler.