### PR TITLE
Make sure examples compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # the terms of the Do What The Fuck You Want To Public License, Version 2, as
 # published by Sam Hocevar. See the COPYING file for more details.
 
-CFLAGS = $(shell pkg-config --cflags $(LIBRARIES)) -std=c99 -g -Wall -Wextra -Werror -Iinclude
+CFLAGS = $(shell pkg-config --cflags $(LIBRARIES)) -std=gnu99 -g -Wall -Wextra -Werror -Iinclude
 LDLIBS = $(shell pkg-config --libs $(LIBRARIES))
 
 LIBRARIES = check glib-2.0

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDLIBS = $(shell pkg-config --libs $(LIBRARIES))
 
 LIBRARIES = check glib-2.0
 
-all: test example
+all: test src/example-at src/example-sim800
 	@echo "+++ All good."""
 
 test: tests/test-parser

--- a/include/attentive/cellular.h
+++ b/include/attentive/cellular.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 
 #include <attentive/at.h>
 

--- a/src/at-unix.c
+++ b/src/at-unix.c
@@ -147,7 +147,8 @@ int at_open(struct at *at)
     if (priv->baudrate) {
         struct termios attr;
         tcgetattr(priv->fd, &attr);
-        cfsetspeed(&attr, priv->baudrate);
+        cfsetispeed(&attr, priv->baudrate);
+        cfsetospeed(&attr, priv->baudrate);
         tcsetattr(priv->fd, TCSANOW, &attr);
     }
 

--- a/src/example-at.c
+++ b/src/example-at.c
@@ -14,7 +14,7 @@
 #include <attentive/at.h>
 #include <attentive/at-unix.h>
 
-static void generic_modem_handle_urc(const void *line, size_t len, void *arg)
+static void generic_modem_handle_urc(const char *line, size_t len, void *arg)
 {
     printf("[%p] URC: %.*s\n", arg, (int) len, (char *) line);
 }

--- a/src/modem/sim800.c
+++ b/src/modem/sim800.c
@@ -215,6 +215,9 @@ static int sim800_detach(struct cellular *modem)
 
 static int sim800_clock_gettime(struct cellular *modem, struct timespec *ts)
 {
+    (void) modem;
+    (void) ts;
+
     /* TODO: See CYC-1255. */
     errno = ENOSYS;
     return -1;
@@ -222,6 +225,9 @@ static int sim800_clock_gettime(struct cellular *modem, struct timespec *ts)
 
 static int sim800_clock_settime(struct cellular *modem, const struct timespec *ts)
 {
+    (void) modem;
+    (void) ts;
+
     /* TODO: See CYC-1255. */
     errno = ENOSYS;
     return -1;
@@ -488,10 +494,10 @@ static ssize_t sim800_socket_recv(struct cellular *modem, int connid, void *buff
 
         /* Find the header line. */
         int requested, confirmed;
-        // TODO: 
+        // TODO:
         // 1. connid is not checked
         // 2. there is possible a bug here. if not all data are ready (confirmed < requested)
-        // then wierd things can happen. see memcpy 
+        // then wierd things can happen. see memcpy
         // requested should be equal to chunk
         // confirmed is that what can be read
         at_simple_scanf(response, "+CIPRXGET: 2,%*d,%d,%d", &requested, &confirmed);
@@ -502,7 +508,7 @@ static ssize_t sim800_socket_recv(struct cellular *modem, int connid, void *buff
             break;
 
         /* Locate the payload. */
-        /* TODO: what if no \n is in input stream? 
+        /* TODO: what if no \n is in input stream?
          * should use strnchr at least */
         const char *data = strchr(response, '\n');
         if (data == NULL) {

--- a/src/modem/sim800.c
+++ b/src/modem/sim800.c
@@ -8,6 +8,7 @@
 
 #include <attentive/cellular.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -258,9 +259,9 @@ static int sim800_clock_ntptime(struct cellular *modem, struct timespec *ts)
                 {
                     ts->tv_sec = (long int)buf[i] + ts->tv_sec*256;
                 }
-                printf("sim800: catched UTC timestamp -> %d\n", ts->tv_sec);
+                printf("sim800: catched UTC timestamp -> %" PRId64 "\n", ts->tv_sec);
                 ts->tv_sec -= 2208988800L;        //UTC to UNIX time conversion
-                printf("sim800: final UNIX timestamp -> %d\n", ts->tv_sec);
+                printf("sim800: final UNIX timestamp -> %" PRId64 "\n", ts->tv_sec);
                 goto close_conn;
             }
 


### PR DESCRIPTION
Add examples to `Makefile` and fix compiler warnings.

The biggest change here was the `-std` change from `c99` to `gnu99` in order to expose `timegm`. I have an alternative `at-timegm` implementation which doesn't enforce `gnu99` onto the callers.